### PR TITLE
Misc css/styling edits

### DIFF
--- a/client/src/components/Navbar.vue
+++ b/client/src/components/Navbar.vue
@@ -19,7 +19,7 @@
       </b-navbar-nav>
     </b-navbar>
 
-    <send-message modalId="broadcast-modal" modalTitle="Announce Message" />
+    <send-message modalId="broadcast-modal" />
   </div>
 </template>
 

--- a/client/src/components/RoomCard.vue
+++ b/client/src/components/RoomCard.vue
@@ -75,8 +75,8 @@
 
       <icon-button
         v-if="showJoin"
-        icon="phone"
-        variant="primary"
+        icon="video"
+        variant="outline-success"
         @click="joinRoom"
       >
         Join
@@ -110,6 +110,7 @@ import { library } from "@fortawesome/fontawesome-svg-core";
 import {
   faComments,
   faPhone,
+  faVideo,
   faEdit,
   faExternalLinkAlt,
   faSave,
@@ -120,6 +121,7 @@ import {
 library.add(
   faComments,
   faPhone,
+  faVideo,
   faEdit,
   faExternalLinkAlt,
   faSave,

--- a/client/src/components/SendMessage.vue
+++ b/client/src/components/SendMessage.vue
@@ -35,8 +35,8 @@ export default class SendMessage extends Vue {
   @Prop({ default: "message-modal" })
   modalId!: string;
 
-  @Prop({ default: "Send Message" })
-  modalTitle!: string;
+  // @Prop({ default: "Send Message" })
+  // modalTitle!: string;
 
   @Prop({ default: null })
   receiver!: number | null;
@@ -44,6 +44,16 @@ export default class SendMessage extends Vue {
   message = "";
 
   name = "send-message";
+
+  get modalTitle() {
+    let receiverName: string;
+    if (this.receiver) {
+      receiverName = this.$store.getters.userById(this.receiver).displayName;
+    } else {
+      receiverName = "everyone";
+    }
+    return "Send a message to " + receiverName;
+  }
 
   send() {
     const sender: User = this.$store.getters.sessionUser;

--- a/client/src/components/UserSummary.vue
+++ b/client/src/components/UserSummary.vue
@@ -35,7 +35,7 @@
         <icon-button
           v-if="showSendMessage"
           icon="comment-alt"
-          variant="success"
+          variant="outline-success"
           @click.stop="sendMessage"
         >
           Message

--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -37,7 +37,7 @@
             You are invisible to others until you join a room
           </p>
           <b-dropdown
-            variant="primary"
+            variant="success"
             id="dropdown-1"
             text="Join"
             class="m-md-2"

--- a/client/src/views/SendInvitations.vue
+++ b/client/src/views/SendInvitations.vue
@@ -12,7 +12,7 @@
             size="sm"
             class="mr-1"
             v-b-modal.import-file-modal
-            variant="outline-primary"
+            variant="outline-success"
             :disabled="sending"
           >
             <font-awesome-icon icon="file-import" /> Import


### PR DESCRIPTION
This PR unifies 

1. the message dialog so it says `everyone` or the recipients name
2. all the buttons to use `success` instead of `primary` 

I'm suggesting (2) largely because I thought green works better as 
an "do this", e.g. is the color of the "create pull request" button on 
github.

Anyways, easy to undo... (but should probably hold on to 1 either way).
 